### PR TITLE
Add systemd-container to additional-packages list

### DIFF
--- a/conf/build.manifest
+++ b/conf/build.manifest
@@ -282,6 +282,9 @@ additional-packages:
 - name: i2c-tools
   comment: requested by platform team (NAS-120155)
   install_recommends: true
+- name: systemd-container
+  comment: requested by community (NAS-123533)
+  install_recommends: true
 
 #
 # List of additional packages installed into TrueNAS SCALE ISO file


### PR DESCRIPTION
As requested in [NAS-123533](https://ixsystems.atlassian.net/browse/NAS-123533).

The systemd-container package, which provides the systemd-nspawn and machinectl commands, was included with SCALE releases prior to version 22.12.3. It was then gone for some releases and seems to be present again in a future version (tested with TrueNAS-SCALE-23.10-MASTER-20230813-042924).

This pull requests adds systemd-container to [the list of additional-packages](https://github.com/truenas/scale-build/blob/release/23.10-BETA.1/conf/build.manifest#L227) to be installed.

Reasons to include it in the list:

- It was included in previous releases and seems to be included in future releases
- Putting it on the list will ensure the package is explicitly included, instead of being installed as an implicit dependency (and won’t disappear suddenly)
- It’s a very small package (about 1MB installed)
- There’s [a community of users](https://github.com/Jip-Hop/jailmaker) relying on systemd-nspawn on SCALE (and we prefer not to have to resort to using apt to bring back systemd-nspawn)